### PR TITLE
Fix #458: Recognize lambda functions

### DIFF
--- a/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
+++ b/scalameta/parsers/src/main/scala/scala/meta/internal/parsers/ScalametaParser.scala
@@ -726,6 +726,8 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
       Some(atPos(tree, tree)(Term.Param(Nil, name, None, None)))
     case name: Term.Placeholder =>
       Some(atPos(tree, tree)(Term.Param(Nil, atPos(name, name)(Name.Anonymous()), None, None)))
+    case Term.Ascribe(name: Term.Name.Quasi, tpe: Type.Quasi) =>
+      Some(atPos(tree, tree)(Term.Param(Nil, name, Some(tpe), None)))
     case Term.Ascribe(name: Term.Name, tpt) =>
       Some(atPos(tree, tree)(Term.Param(Nil, name, Some(tpt), None)))
     case Term.Ascribe(name: Term.Placeholder, tpt) =>
@@ -1660,6 +1662,7 @@ class ScalametaParser(input: Input, dialect: Dialect) { parser =>
               case Term.Quasi(0, _) => true
               case Term.Quasi(1, ParamLike()) => true
               case NameLike() => true
+              case Term.Ascribe(ParamLike(), _) => true
               case Term.Ascribe(NameLike(), _) => true
               case _ => false
             }

--- a/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
+++ b/scalameta/scalameta/src/test/scala/scala/meta/tests/quasiquotes/SuccessSuite.scala
@@ -2234,4 +2234,11 @@ class SuccessSuite extends FunSuite {
       |}
     """.trim.stripMargin)
   }
+
+  test("#458") {
+    val name = q"x"
+    val tpe = t"T"
+    val lambda = q"($name: $tpe) => ???"
+    assert(lambda.syntax === "(x: T) => ???")
+  }
 }


### PR DESCRIPTION
When parsing quasiquotes, the internal structure of the tree changes. The
previous ascribe case defs were not accounting for the fact that the name and
the type could be quasi.
